### PR TITLE
The correct way to get current URL is qualified_me(). Accessing $PAGE…

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -33,7 +33,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright  2015 David Monllao {@link http://www.davidmonllao.com} and 2016 Tim Williams for Streaing LTD (copied from mod_page)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class activity extends \core_search\area\base_activity {
+class activity extends \core_search\base_activity {
 
 
     /**

--- a/settings.php
+++ b/settings.php
@@ -8,12 +8,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-global $CFG;
 require_once($CFG->dirroot.'/mod/helixmedia/lib.php');
 require_once($CFG->dirroot.'/mod/lti/locallib.php');
 
-
-if ($PAGE->url->get_param("section")=="modsettinghelixmedia") {
+if (strpos(qualified_me(), 'modsettinghelixmedia') !== false) {
     require_once($CFG->dirroot.'/mod/helixmedia/locallib.php');
     $settings->add(new admin_setting_heading('helixmedia/version_check', get_string("version_check_title", "mod_helixmedia"),
         helixmedia_version_check()));
@@ -61,7 +59,7 @@ $settings->add(new admin_setting_configcheckbox('helixmedia/forcedebug', get_str
 
 $settings->add(new admin_setting_configcheckbox('helixmedia/restrictdebug', get_string('restrictdebug', 'helixmedia'), get_string('restrictdebug_help', 'helixmedia'), 1));
 
-if ($PAGE->url->get_param("section")=="modsettinghelixmedia") {
+if (strpos(qualified_me(), 'modsettinghelixmedia') !== false) {
 
     $settings->add(new admin_setting_heading('helixmedia/repo_migrate', get_string("repo_migrate_title", "mod_helixmedia"),
         "<p>".get_string("repo_migrate_message", "mod_helixmedia")."</p>".


### PR DESCRIPTION
… directly can cause exceptions. Also global $CFG is not required - we are already in global scope. Fixes streamingltd/MEDIAL-Moodle-Activity#5