### PR TITLE
Updates for Moodle 4.3+

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -125,6 +125,11 @@ function helixmedia_preallocate_id() {
  */
 function helixmedia_get_preid($cmid) {
     global $DB;
+
+    if ($cmid == null) {
+        return null;
+    }
+
     $cm = get_coursemodule_from_id('helixmedia', $cmid, 0, false, MUST_EXIST);
     $hmli = $DB->get_record('helixmedia', array('id' => $cm->instance), '*', MUST_EXIST);
     return $hmli->preid;


### PR DESCRIPTION
return null if $cmid is null for helixmedia_get_preid() in lib.php.

Since Moodle 4.3 showing the "Default activity completion"  for a course will trigger the definition() method in mod_form.php.
This will result in an error as $cmid is still null at that time and get_coursemodule_from_id() will fail to return a MUST_EXIST object.

This will fix #15.