### PR TITLE
Fixing issues for MOODLE_403_STABLE

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -125,6 +125,11 @@ function helixmedia_preallocate_id() {
  */
 function helixmedia_get_preid($cmid) {
     global $DB;
+
+    if ($cmid == null) {
+        return null;
+    }
+
     $cm = get_coursemodule_from_id('helixmedia', $cmid, 0, false, MUST_EXIST);
     $hmli = $DB->get_record('helixmedia', array('id' => $cm->instance), '*', MUST_EXIST);
     return $hmli->preid;

--- a/locallib.php
+++ b/locallib.php
@@ -149,9 +149,12 @@ function helixmedia_curl_post_launch_html($params, $endpoint) {
     $result = $curl->post($endpoint, $params);
     $resp = $curl->get_info();
     if ($curl->get_errno() != CURLE_OK || $resp['http_code'] != 200) {
-        $r = $curl->get_raw_response();
-        return "<p>CURL Error connecting to MEDIAL: ".$r[0]."</p>".
-              "<p>".get_string("version_check_fail", "helixmedia")."</p>";
+        if ($r = $curl->get_raw_response()) {
+            return "<p>CURL Error connecting to MEDIAL: ".$r[0]."</p>".
+                "<p>".get_string("version_check_fail", "helixmedia")."</p>";
+        } else {
+            return "N";
+        }
     }
 
     if (file_exists($cookiesfile)) {


### PR DESCRIPTION
return null if $cmid is null for helixmedia_get_preid(), fixes #15
checking if get_raw_response() returns a result before tyring to use it, fixes, fixes #17