### PR TITLE
Adapt mobile code to app 4.4

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -80,7 +80,8 @@ class mobile {
             'cmid' => $cm->id,
             'courseid' => $args->courseid,
             'launchurl' => $launchurl,
-            'showdescription' => $helixmedia->showdescriptionlaunch
+            'description' => $helixmedia->showdescriptionlaunch ? $helixmedia->intro : '',
+            'canusemoduleinfo' => $args->appversioncode >= 44000,
         );
 
         if ($size->audioonly) {

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->dirroot.'/mod/helixmedia/lib.php');
 require_once($CFG->dirroot.'/mod/helixmedia/locallib.php');
+require_once("$CFG->libdir/externallib.php");
 
 use context_module;
 use mod_helixmedia_external;

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -1,6 +1,10 @@
 <div style='margin-left:0px;margin-right:0px;' id='helixcontainer'>
-    {{#showdescription}}
-    <core-course-module-description description="{{helixmedia.intro}}" component="mod_helixmedia" componentId="{{cmid}}"></core-course-module-description>
-    {{/showdescription}}
+    {{#canusemoduleinfo}}
+        <core-course-module-info [module]="module" description="{{description}}" component="mod_helixmedia" componentId="{{cmid}}" [courseId]="courseId">
+        </core-course-module-info>
+    {{/canusemoduleinfo}}
+    {{^canusemoduleinfo}}
+        <core-course-module-description description="{{description}}" component="mod_helixmedia" componentId="{{cmid}}"></core-course-module-description>
+    {{/canusemoduleinfo}}
     <iframe allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" id="contentframe" height="{{height}}" width="100%" src="{{launchurl}}" style='margin-left:0px;margin-right:0px'></iframe>
 </div>


### PR DESCRIPTION
In this PR I removed the usage of core-course-module-description component for newer app versions, it is deprecated and will be removed in a future version of the app. It should have been removed already, but we kept it in the app because some plugins still use it.

Also, opening the plugin in the app returned an exception, I fixed it too.