### PR TITLE
#29 the parent function of definition_after_data must be called

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -78,6 +78,7 @@ class mod_helixmedia_mod_form extends moodleform_mod {
     }
 
     function definition_after_data() {
+        parent::definition_after_data();
         global $PAGE, $add, $update;
         $mform =& $this->_form;
         $pr =& $mform->getElement('preid');


### PR DESCRIPTION
**Main reason**: In the latest version 8.5.19e (2024120901) of the `mod_helixmedia module`, the function `definition_after_data` (https://github.com/streamingltd/moodle-mod_helixmedia/commit/15e0c78267dd9b329607e77db7f756f480505d58#diff-aa9511a4531a05e51ca336401c5f892ca096725e2f94b6fce8dd8f0c9fe3b181R80) was overridden without calling the parent function definition_after_data. However, every module that defines its own definition_after_data function must call this parent function. More specifically, the form element of completion is completed by function `definition_after_data_completion`, which is called within this parent function of `definition_after_data` .

**Solution**: In the function `definition_after_data` of mod_helixmedia, this parent function should be called.