### PR TITLE
Include locallib.php to be able to use LTI_VERSION_1P3 constant

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+require_once($CFG->dirroot . '/mod/helixmedia/locallib.php');
+
 /**
  * This file contains a library of functions and constants for the helixmedia module
  *


### PR DESCRIPTION
Fixes #35.

Of course, including locallib.php in lib.php makes locallib.php rather useless...I propose you extract classes for all later.